### PR TITLE
Add support for AWS China partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform module to create an S3 bucket for storing service logs:
 
 * `bucket` - Bucket name.
 * `force_destroy` - Allow remove bucket with its content (Default: `false`).
-* `readers` - A list of AWS accounts who can read from bucket (Default: `[]`).
+* `readers` - A list of AWS accounts who can read from bucket (Default: `[]`). If only the AWS account number is specified, the global `aws` partition is assumed.
 * `cdn_logs_path` - Prefix for CloudFront logs (Default: `cdn`)
 * `alb_logs_path` - Prefix for ALB logs (Default: `alb`)
 * `s3_logs_path` - Prefix for S3 access logs (Default: `s3`)
@@ -37,10 +37,10 @@ resource "aws_s3_bucket" "example" {
 Default values 
 ```hcl
 module "log_storage" {
-  source        = "github.com/jetbrains-infra/terraform-aws-s3-bucket-for-logs?ref=X.X.X" // see https://github.com/jetbrains-infra/terraform-aws-s3-bucket-for-logs/releases/latest
-  bucket        = "example-logs"
-  force_destroy = false
-  readers       = []
+  source                  = "github.com/jetbrains-infra/terraform-aws-s3-bucket-for-logs?ref=X.X.X" // see https://github.com/jetbrains-infra/terraform-aws-s3-bucket-for-logs/releases/latest
+  bucket                  = "example-logs"
+  force_destroy           = false
+  readers                 = []
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform module to create an S3 bucket for storing service logs:
 
 * `bucket` - Bucket name.
 * `force_destroy` - Allow remove bucket with its content (Default: `false`).
-* `readers` - A list of AWS accounts who can read from bucket (Default: `[]`). If only the AWS account number is specified, the global `aws` partition is assumed.
+* `readers` - A list of AWS accounts who can read from bucket (Default: `[]`)
 * `cdn_logs_path` - Prefix for CloudFront logs (Default: `cdn`)
 * `alb_logs_path` - Prefix for ALB logs (Default: `alb`)
 * `s3_logs_path` - Prefix for S3 access logs (Default: `s3`)

--- a/s3_bucket_policy.tf
+++ b/s3_bucket_policy.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "cloudfront" {
 data "aws_iam_policy_document" "external_readers" {
   statement {
     principals {
-      identifiers = concat(formatlist("arn:aws:iam::%s:root", local.reader_account_numbers), local.reader_full_arns)
+      identifiers = formatlist("arn:${data.aws_partition.current.partition}:iam::%s:root", local.readers)
       type        = "AWS"
     }
     actions = [
@@ -82,9 +82,4 @@ data "aws_iam_policy_document" "bucket_policy" {
     data.aws_iam_policy_document.cloudfront.json,
     data.aws_iam_policy_document.external_readers.json
   ]
-}
-
-locals {
-  reader_full_arns       = [for r in local.readers : r if length(regexall("^arn:aws(-cn|-us-gov)?:", r)) > 0]
-  reader_account_numbers = setsubtract(local.readers, local.reader_full_arns)
 }

--- a/s3_bucket_policy.tf
+++ b/s3_bucket_policy.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "s3" {
     actions = [
       "s3:PutObject"
     ]
-    resources = ["arn:aws:s3:::${local.bucket}/${local.s3_logs_prefix}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${local.bucket}/${local.s3_logs_prefix}/*"]
   }
 }
 
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "alb" {
       type        = "AWS"
     }
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${local.bucket}/${local.alb_logs_prefix}/AWSLogs/${local.account_id}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${local.bucket}/${local.alb_logs_prefix}/AWSLogs/${local.account_id}/*"]
   }
 
   statement {
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "alb" {
       type        = "Service"
     }
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${local.bucket}/${local.alb_logs_prefix}/AWSLogs/${local.account_id}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${local.bucket}/${local.alb_logs_prefix}/AWSLogs/${local.account_id}/*"]
     condition {
       test     = "StringEquals"
       values   = ["bucket-owner-full-control"]
@@ -42,28 +42,27 @@ data "aws_iam_policy_document" "alb" {
       type        = "Service"
     }
     actions   = ["s3:GetBucketAcl"]
-    resources = ["arn:aws:s3:::${local.bucket}"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${local.bucket}"]
   }
 }
 
 data "aws_iam_policy_document" "cloudfront" {
   statement {
     principals {
-      // Canonical ID transforms to this value and there is always drift
-      // "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+      // Grant permission to awslogsdelivery by specifying the account's canonical ID
       // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
-      identifiers = ["arn:aws:iam::162777425019:root"]
-      type        = "AWS"
+      identifiers = [lookup(local.canonical_ids, data.aws_partition.current.partition)]
+      type        = "CanonicalUser"
     }
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${local.bucket}/${var.cdn_logs_path}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${local.bucket}/${var.cdn_logs_path}/*"]
   }
 }
 
 data "aws_iam_policy_document" "external_readers" {
   statement {
     principals {
-      identifiers = formatlist("arn:aws:iam::%s:root", local.readers)
+      identifiers = concat(formatlist("arn:aws:iam::%s:root", local.reader_account_numbers), local.reader_full_arns)
       type        = "AWS"
     }
     actions = [
@@ -83,4 +82,9 @@ data "aws_iam_policy_document" "bucket_policy" {
     data.aws_iam_policy_document.cloudfront.json,
     data.aws_iam_policy_document.external_readers.json
   ]
+}
+
+locals {
+  reader_full_arns       = [for r in local.readers : r if length(regexall("^arn:aws(-cn|-us-gov)?:", r)) > 0]
+  reader_account_numbers = setsubtract(local.readers, local.reader_full_arns)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,7 @@ variable "readers" {
 }
 data "aws_elb_service_account" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 locals {
   bucket                  = var.bucket
@@ -58,6 +59,10 @@ locals {
   elb_service_account_arn = data.aws_elb_service_account.current.arn
   readers                 = var.readers
   force_destroy           = var.force_destroy
+  canonical_ids = {
+    "aws-cn" = "a52cb28745c0c06e84ec548334e44bfa7fc2a85c54af20cd59e4969344b7af56", // https://docs.amazonaws.cn/en_us/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
+    "aws"    = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"  // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
+  }
 
   tags = {
     Module       = "S3 Bucket for Logs"


### PR DESCRIPTION
Hi,

this PR adds support for AWS China (`aws-cn`).   
There are two caveats I want to bring to your attention:  
1. I assume that only ARNs of the same partition can be referenced. As such, the `external_readers` policy will bind the given account numbers to `data.aws_partition.current.partition`.  
The alternative would be the specification of a full account ARN (which could be part of another AWS partition). This could be implemented in a backwards-compatible way such that it's possible to specify both account numbers as well as full account ARNs **but I dont think granting access to an account from another AWS partition is possible.**   
2. AWS GovCloud is not supported because I didnt find information about which `canonical_id` to use for granting CFN access log rights to S3.  Adding support can be done by adding `aws-us-gov` with the corresponding `canonical_id` to  the `local.canonical_ids` object.


