### PR TITLE
fix(infra): add server_side_encryption configuration 

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,2 @@
+data "aws_elb_service_account" "current" {}
+data "aws_caller_identity" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  bucket                                                            = var.bucket
+  s3_logs_prefix                                                    = var.s3_logs_path
+  alb_logs_prefix                                                   = var.alb_logs_path
+  account_id                                                        = data.aws_caller_identity.current.account_id
+  elb_service_account_arn                                           = data.aws_elb_service_account.current.arn
+  readers                                                           = var.readers
+  force_destroy                                                     = var.force_destroy
+  server_side_encryption_configuration_bucket_key_enabled           = var.server_side_encryption_configuration_bucket_key_enabled
+  server_side_encryption_configuration_bucket_key_sse_algorithm     = var.server_side_encryption_configuration_bucket_key_sse_algorithm
+  server_side_encryption_configuration_bucket_key_kms_master_key_id = var.server_side_encryption_configuration_bucket_key_kms_master_key_id
+  tags = {
+    Module       = "S3 Bucket for Logs"
+    ModuleSource = "https://github.com/jetbrains-infra/terraform-aws-s3-bucket-for-logs/"
+  }
+}

--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -1,7 +1,16 @@
 resource "aws_s3_bucket" "logs" {
   bucket        = local.bucket
   force_destroy = local.force_destroy
-  tags          = local.tags
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = local.server_side_encryption_configuration_bucket_key_sse_algorithm
+        kms_master_key_id = local.server_side_encryption_configuration_bucket_key_kms_master_key_id
+      }
+      bucket_key_enabled = local.server_side_encryption_configuration_bucket_key_enabled
+    }
+  }
+  tags = local.tags
 }
 
 resource "aws_s3_bucket_policy" "logs" {

--- a/variables.tf
+++ b/variables.tf
@@ -47,20 +47,22 @@ variable "readers" {
   type        = list(string)
   default     = []
 }
-data "aws_elb_service_account" "current" {}
-data "aws_caller_identity" "current" {}
-
-locals {
-  bucket                  = var.bucket
-  s3_logs_prefix          = var.s3_logs_path
-  alb_logs_prefix         = var.alb_logs_path
-  account_id              = data.aws_caller_identity.current.account_id
-  elb_service_account_arn = data.aws_elb_service_account.current.arn
-  readers                 = var.readers
-  force_destroy           = var.force_destroy
-
-  tags = {
-    Module       = "S3 Bucket for Logs"
-    ModuleSource = "https://github.com/jetbrains-infra/terraform-aws-s3-bucket-for-logs/"
+variable "server_side_encryption_configuration_bucket_key_enabled" {
+  description = "Specify if to use Amazon S3 Bucket Keys for SSE-KMS."
+  type        = bool
+  default     = false
+}
+variable "server_side_encryption_configuration_bucket_key_sse_algorithm" {
+  description = "Specify what server-side encryption algorithm to use."
+  validation {
+    condition     = regexall("AES256|aws:kms", var.server_side_encryption_configuration_bucket_key_sse_algorithm)
+    error_message = "Supported values are AES256 or aws:kms."
   }
+  type    = string
+  default = "AES256"
+}
+variable "server_side_encryption_configuration_bucket_key_kms_master_key_id" {
+  description = "Specify the configuration for the server side configuration of the S3 bucket."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
# Description

This PR overcomes a recent change in the S3 backend where the server side encryption became mandatory.

This PR follows the least invasive approach to implement this change. By default, the S3 bucket will have  the following
configuration:

```
 server_side_encryption_configuration {
    rule {
      apply_server_side_encryption_by_default {
        sse_algorithm = "AES256"
      }
      bucket_key_enabled = false
    }
  }
}
```