### PR TITLE
fix: condition in the server_side_encryption_configuration_bucket_key_sse_algorithm variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "server_side_encryption_configuration_bucket_key_enabled" {
 variable "server_side_encryption_configuration_bucket_key_sse_algorithm" {
   description = "Specify what server-side encryption algorithm to use."
   validation {
-    condition     = regexall("AES256|aws:kms", var.server_side_encryption_configuration_bucket_key_sse_algorithm)
+    condition     = can(regexall("AES256|aws:kms", var.server_side_encryption_configuration_bucket_key_sse_algorithm))
     error_message = "Supported values are AES256 or aws:kms."
   }
   type    = string


### PR DESCRIPTION
# Description

This PR fixes this issue:

```
╷
│ Error: Invalid variable validation result
│
│   on .terraform/modules/main.packages-cdn-log_storage/variables.tf line 58, in variable "server_side_encryption_configuration_bucket_key_sse_algorithm":
│   58:     condition     = regexall("AES256|aws:kms", var.server_side_encryption_configuration_bucket_key_sse_algorithm)
│     ├────────────────
│     │ var.server_side_encryption_configuration_bucket_key_sse_algorithm is "AES256"
│
│ Invalid validation condition result value: bool required.
```