### PR TITLE
Enable S3 access control lists (ACLs) 

### DIFF
--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -13,6 +13,14 @@ resource "aws_s3_bucket" "logs" {
   tags = local.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  depends_on = [aws_s3_bucket_policy.logs]
+  bucket = aws_s3_bucket.logs.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_policy" "logs" {
   bucket = aws_s3_bucket.logs.id
   policy = data.aws_iam_policy_document.bucket_policy.json


### PR DESCRIPTION
Starting in April 2023, you will need to enable S3 access control lists (ACLs) for new S3 buckets being used for CloudFront standard logs.
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html